### PR TITLE
Add running `./manage.py migrate --run-syncdb` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Make sure you are using a virtual environment of some sort (e.g. `virtualenv` or
 ```
 pip install -r requirements.txt
 ./manage.py migrate
+./manage.py migrate --run-syncdb
 ./manage.py loaddata sites
 ./manage.py runserver
 ```


### PR DESCRIPTION
Fixes issues with the team-wiki application not working (specifically the profiles app as well as pinax-wiki)
