### PR TITLE
Bump required versions of pinax-teams and django-reversion to latest stable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ django-user-accounts==1.3.1
 pinax-wiki==0.2.2
 Pillow==2.9.0
 easy-thumbnails==2.2
-pinax-teams==0.1.1
-django-reversion==1.9.3
+pinax-teams==0.12.1
+django-reversion==1.10.2
 pinax-webanalytics==2.0.4
 pinax-eventlog==1.1.2
 


### PR DESCRIPTION
Fixes some issues that prevented team-wiki from working and brings things up-to-date.
