### PR TITLE
Correct template tag for `pinax.teams` due to namespace change from `…

### DIFF
--- a/project_name/templates/dashboard.html
+++ b/project_name/templates/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "site_base.html" %}
 
-{% load teams_tags %}
+{% load pinax_teams_tags %}
 
 {% block head_title %}pinax-project-team-wiki{% endblock %}
 


### PR DESCRIPTION
…teams`
