### PR TITLE
Correct template tag for `pinax.teams` due to namespace change from `…

### DIFF
--- a/project_name/templates/homepage.html
+++ b/project_name/templates/homepage.html
@@ -1,7 +1,7 @@
 {% extends "site_base.html" %}
 
 {% load i18n %}
-{% load teams_tags %}
+{% load pinax_teams_tags %}
 
 {% block head_title %}pinax-project-team-wiki{% endblock %}
 


### PR DESCRIPTION
…teams`
