### PR TITLE
Set LOGIN_URL in settings.py

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -185,6 +185,8 @@ ACCOUNT_LOGOUT_REDIRECT_URL = "home"
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 2
 ACCOUNT_USE_AUTH_AUTHENTICATE = True
 
+LOGIN_URL = "account_login"
+
 AUTHENTICATION_BACKENDS = [
     "account.auth_backends.UsernameAuthenticationBackend",
 ]


### PR DESCRIPTION
The [LOGIN_URL](https://docs.djangoproject.com/en/1.10/ref/settings/#login-url) default is /accounts/login/ which breaks since the django-user-accounts app login url is reverse('account_login').

The 404 happens with you hit a @login_required URL without being logged in yet.

This fixes the issue so that when hitting a login-protected URL, the user gets properly redirected to the login page.