### PR TITLE
Fixing static project urls

### DIFF
--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -1,9 +1,10 @@
 {% if django_version < "2" %}from django.conf.urls import url{% endif %}
 {% if django_version >= "2" %}from django.urls import path{% endif %}
+from {{ project_name }} import views
 
 
 urlpatterns = [{% if django_version >= "2" %}
-    path("<str:path>", "{{ project_name }}.views.static_view"),
+    path("<str:path>", views.static_view),
 {% else %}
-    url(r"^(.*)$", "{{ project_name }}.views.static_view"),
+    url(r"^(.*)$", views.static_view),
 {% endif %}]


### PR DESCRIPTION
This patch is based on the following issue: https://github.com/pinax/pinax-starter-projects/issues/55. I believe starter project setup should now work for both Django >= 2 and less.