### PR TITLE
Schemaless asset urls

### DIFF
--- a/project_name/templates/_footer.html
+++ b/project_name/templates/_footer.html
@@ -10,7 +10,7 @@
     Made with Pinax
     <div class="patches">
         {% for app in pinax_apps %}
-            <img src="//pinax.github.com/pinax-design/patches/{{ app }}.svg" />
+            <img src="//pinax.github.io/pinax-design/patches/{{ app }}.svg" />
         {% endfor %}
     </div>
 </div>

--- a/project_name/templates/_footer.html
+++ b/project_name/templates/_footer.html
@@ -10,7 +10,7 @@
     Made with Pinax
     <div class="patches">
         {% for app in pinax_apps %}
-            <img src="http://pinax.github.com/pinax-design/patches/{{ app }}.svg" />
+            <img src="//pinax.github.com/pinax-design/patches/{{ app }}.svg" />
         {% endfor %}
     </div>
 </div>

--- a/project_name/templates/homepage.html
+++ b/project_name/templates/homepage.html
@@ -23,7 +23,7 @@
                 projects are based.
                 {% endblocktrans %}
             </p>
-            <img src="http://pinaxproject.com/pinax-design/tessellations/Project%20Zero.png" />
+            <img src="//pinaxproject.com/pinax-design/tessellations/Project%20Zero.png" />
         </div>
     </section>
     <section id="content-section">


### PR DESCRIPTION
Use schemaless static assets URLs to avoid nasty browser warnings when serving https.  Also avoid a github insecure redirect.